### PR TITLE
Adding support for prepending to lists.

### DIFF
--- a/src/qbits/hayt/cql.clj
+++ b/src/qbits/hayt/cql.clj
@@ -115,6 +115,10 @@ for a more up to date version "
                 >= ">="
                 + "+"
                 - "-"})
+(defn operator?
+  [op]
+  (or (keyword? op)
+      (not (nil? (get operators op)))))
 
 (defn config-value
   [x]
@@ -150,13 +154,19 @@ for a more up to date version "
            " " (name op) " "
            (cql-value value)))))
 
-(defn counter [column [op value]]
+;; oov stands for operator-or-value
+(defn counter [column [oov1 oov2]]
   (format-eq (cql-identifier column)
              ;; We cannot cache the col-name value, since there is a
              ;; stack update behind this call
-             (join-spaced [(cql-identifier column)
-                           (operators op)
-                           (cql-value value)])))
+             (join-spaced
+              (if (operator? oov1)
+                [(cql-identifier column)
+                 (operators oov1)
+                 (cql-value oov2)]
+                [(cql-value oov1)
+                 (operators oov2)
+                 (cql-identifier column)]))))
 
 (def emit
   {:columns

--- a/test/qbits/hayt/core_test.clj
+++ b/test/qbits/hayt/core_test.clj
@@ -79,6 +79,11 @@
        (update :foo
                (set-columns {:bar 1
                              :baz [+ {"key" "value"}] })
+               (where {:foo :bar}))
+
+       "UPDATE foo SET baz = ['prepended'] + baz WHERE foo = 'bar';"
+       (update :foo
+               (set-columns {:baz [["prepended"] +] })
                (where {:foo :bar})))
 
 


### PR DESCRIPTION
This PR adds support for:

Adding (appending or prepending) values to a list can be accomplished by adding a new JSON-style array to an existing list column.

``` sql
UPDATE plays SET players = 5, scores = scores + [ 14, 21 ] WHERE id = '123-afde';
UPDATE plays SET players = 5, scores = [ 12 ] + scores WHERE id = '123-afde';
```

Adding was working fine, but prepending wasn't.

I realize that code does not read well, but (smart) alternative would look even more counter-intutive: it'd be map over operator-or-value function which would turn operator into operator and cql-value for value  + reverse if we're in backwards order.
