### PR TITLE
keywords keep the namespace when converted to cql values

### DIFF
--- a/src/clj/qbits/hayt/cql.clj
+++ b/src/clj/qbits/hayt/cql.clj
@@ -73,7 +73,10 @@ And a useful test suite: https://github.com/riptano/cassandra-dtest/blob/master/
   clojure.lang.Keyword
   (cql-identifier [x] (name x))
   (cql-value [x]
-    (maybe-parameterize! x #(cql-value (name %))))
+    (maybe-parameterize! x
+      #(cql-value (if-let [nsp (namespace %)]
+                      (str nsp "/" (name %))
+                      (name %)))))
 
   Date
   (cql-value [x]


### PR DESCRIPTION
The use of "name" to convert a Keyword to a cql-value String was causing
the namespace to be lost. This commit fixes that, so when there is a
namespace it is included in the resulting string. Otherwise behaviour
remains the same as before.
