### PR TITLE
Distinct counter updates from list column updates

### DIFF
--- a/src/clj/qbits/hayt/cql.clj
+++ b/src/clj/qbits/hayt/cql.clj
@@ -508,7 +508,7 @@ And a useful test suite: https://github.com/riptano/cassandra-dtest/blob/master/
    (fn [q values]
      (->> values
           (map (fn [[k v]]
-                 (if (vector? v)
+                 (if (and (vector? v) (some operator? v))
                    (counter k v)
                    (format-eq (cql-identifier k)
                               (cql-value v)))))

--- a/test/qbits/hayt/core_test.clj
+++ b/test/qbits/hayt/core_test.clj
@@ -126,6 +126,10 @@
            (set-columns :bar 1
                         :baz [+ 2]))
 
+   "UPDATE foo SET baz = [1, 2];"
+   (update :foo
+           (set-columns :baz [1 2]))
+
    "UPDATE foo SET bar = 1, baz = baz + 2 WHERE foo = 'bar' AND moo > 3 AND meh > 4 AND baz IN (5, 6, 7);"
    (update :foo
            (set-columns [[:bar 1]


### PR DESCRIPTION
Notation `(set-columns :baz [1 2])` can be used to produce list columns
update. But having vector as an update argument implied it will have an
operator inside.
Condition added to check are there any operators in passed
vector and if there are none default formatter is used instead of
counter formatter.