### PR TITLE
Batch query indentation fix.

### DIFF
--- a/src/clj/qbits/hayt/cql.clj
+++ b/src/clj/qbits/hayt/cql.clj
@@ -692,7 +692,7 @@
            (cond->
                (not logged) (str! " UNLOGGED")
                counter (str! " COUNTER"))
-           (str! " BATCH")
+           (str! " BATCH ")
            (cond->
                using (-> ((emit :using) q using)
                          (str! " \n")))


### PR DESCRIPTION
Hi,
I've ran into an issue trying to perform batch inserts with hayt. 
`(h/batch
           (h/queries
             (h/insert ...)
             (h/insert ...)
             (h/insert ...)))`
Which generated the following cql code:
`BEGIN BATCHINSERT INTO ...
 ... APPLY BATCH`
So basically the trailing space before the first query was missing.
Thought it'd be an easy thing to fix. 